### PR TITLE
Solve Undefined index: H at Sync.php#209

### DIFF
--- a/lib/Horde/Imap/Client/Data/Sync.php
+++ b/lib/Horde/Imap/Client/Data/Sync.php
@@ -205,7 +205,7 @@ class Horde_Imap_Client_Data_Sync
 
         /* Flag changes. */
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGS)) {
-            $this->flags = !($this->highestmodseq && isset($curr['H']) && $this->highestmodseq != $curr['H']);
+            $this->flags = !($this->highestmodseq && isset($curr['H']) && ($this->highestmodseq != $curr['H']));
         }
 
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {

--- a/lib/Horde/Imap/Client/Data/Sync.php
+++ b/lib/Horde/Imap/Client/Data/Sync.php
@@ -205,9 +205,7 @@ class Horde_Imap_Client_Data_Sync
 
         /* Flag changes. */
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGS)) {
-            $this->flags = $this->highestmodseq
-                ? ($this->highestmodseq != $curr['H'])
-                : true;
+            $this->flags = !($this->highestmodseq && isset($curr['H']) && $this->highestmodseq != $curr['H']);
         }
 
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {

--- a/lib/Horde/Imap/Client/Data/Sync.php
+++ b/lib/Horde/Imap/Client/Data/Sync.php
@@ -205,7 +205,9 @@ class Horde_Imap_Client_Data_Sync
 
         /* Flag changes. */
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGS)) {
-            $this->flags = !($this->highestmodseq && isset($curr['H']) && ($this->highestmodseq == $curr['H']));
+            $this->flags = $this->highestmodseq
+                ? !isset($curr['H']) || ($this->highestmodseq != $curr['H'])
+                : true;
         }
 
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {

--- a/lib/Horde/Imap/Client/Data/Sync.php
+++ b/lib/Horde/Imap/Client/Data/Sync.php
@@ -205,7 +205,7 @@ class Horde_Imap_Client_Data_Sync
 
         /* Flag changes. */
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGS)) {
-            $this->flags = !($this->highestmodseq && isset($curr['H']) && ($this->highestmodseq != $curr['H']));
+            $this->flags = !($this->highestmodseq && isset($curr['H']) && ($this->highestmodseq == $curr['H']));
         }
 
         if ($sync_all || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {


### PR DESCRIPTION
I am getting this error on owncloud mail. I don't know why $curr['H'] is undefined but at least it doesn't fill my logs.

I eliminated the ternary operator because it doesn't make much sense when you are dealing with booleans